### PR TITLE
Serializers branch

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -2,8 +2,19 @@ class Api::V1::PostersController < ApplicationController
 
     def index
         # render json: Poster.all
-        posters = Poster.all
+        if params[:sort] == 'desc'
+            sort_order = :desc 
+        else
+            sort_order = :asc 
+        end
+        
+        posters = Poster.order(created_at: sort_order)
         render json: PosterSerializer.format_posters(posters)
+        #do conditional checking to see if the param exist via query params = application/biz logic
+        #after verifying that this key exists, then what has to be achieved to that data should be 
+        #abstracted to the model 
+
+
     end
 
     def show

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,15 +1,14 @@
 class Api::V1::PostersController < ApplicationController
 
-    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-
     def index
         # render json: Poster.all
-        posters = Poster.all 
-        render json: posters
+        posters = Poster.all
+        render json: PosterSerializer.format_posters(posters)
     end
 
     def show
-        render json: Poster.find(params[:id])
+        # render json: Poster.find(params[:id])
+        render json: PosterSerializer.format_single_poster(Poster.find(params[:id]))
     end
 
     def create
@@ -39,9 +38,6 @@ class Api::V1::PostersController < ApplicationController
         params.require(:poster).permit(:name, :description, :price, :year, :vintage, :img_url)
     end
 
-    def record_not_found(error)
-        render json: { error: "Poster not found" }, status: :not_found
-    end
 
 
 end

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,20 +1,30 @@
 class Api::V1::PostersController < ApplicationController
 
     def index
-        # render json: Poster.all
+        #sorting logic
         if params[:sort] == 'desc'
             sort_order = :desc 
         else
             sort_order = :asc 
         end
+
+        #base query
+        posters = Poster.all
+
+        #filtering logic
+        if params[:name]
+            posters = posters.where("lower(name) LIKE ?", "%#{params[:name].downcase}%").order(:name)
+        elsif params[:max_price]
+            posters = posters.where("price <= ?", params[:max_price])
+        elsif params[:min_price]
+            posters = posters.where("price >= ?", params[:min_price])
+        end
         
-        posters = Poster.order(created_at: sort_order)
+        #apply sorting 
+        posters = posters.order(created_at: sort_order)
+
+        #format json response 
         render json: PosterSerializer.format_posters(posters)
-        #do conditional checking to see if the param exist via query params = application/biz logic
-        #after verifying that this key exists, then what has to be achieved to that data should be 
-        #abstracted to the model 
-
-
     end
 
     def show

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::PostersController < ApplicationController
 
     def index
+         #base query
+         posters = Poster.all
+         
         #sorting logic
         if params[:sort] == 'desc'
             sort_order = :desc 
@@ -8,15 +11,16 @@ class Api::V1::PostersController < ApplicationController
             sort_order = :asc 
         end
 
-        #base query
-        posters = Poster.all
-
         #filtering logic
         if params[:name]
             posters = posters.where("lower(name) LIKE ?", "%#{params[:name].downcase}%").order(:name)
-        elsif params[:max_price]
+        end
+
+        if params[:max_price]
             posters = posters.where("price <= ?", params[:max_price])
-        elsif params[:min_price]
+        end
+        
+        if params[:min_price]
             posters = posters.where("price >= ?", params[:min_price])
         end
         

--- a/app/serializers/poster_serializer.rb
+++ b/app/serializers/poster_serializer.rb
@@ -1,0 +1,41 @@
+class PosterSerializer
+  def self.format_posters(posters)
+    {
+      data: posters.map do |poster|
+        {
+          id: poster.id.to_s,
+          type: "poster",
+          attributes: {
+            name: poster.name,
+            description: poster.description,
+            price: poster.price,
+            year: poster.year,
+            vintage: poster.vintage,
+            img_url: poster.img_url
+          }
+        }
+      end, 
+      meta: {count: posters.count}
+    }
+  end
+
+  def self.format_single_poster(poster)
+    {
+      data: {
+        id: poster.id.to_s,
+        type: "poster",
+        attributes: {
+          name: poster.name,
+          description: poster.description,
+          price: poster.price,
+          year: poster.year,
+          vintage: poster.vintage,
+          img_url: poster.img_url
+        }
+      }
+    }
+  end
+
+
+
+end

--- a/spec/api/v1/posters_controller_spec.rb
+++ b/spec/api/v1/posters_controller_spec.rb
@@ -38,7 +38,7 @@ describe "Posters API", type: :request do
 
     posters.each do |poster|  
       expect(poster).to have_key(:id)
-      expect(poster[:id]).to be_an(Integer)
+      expect(poster[:id]).to be_an(String)
 
       expect(poster).to have_key(:name)
       expect(poster[:name]).to be_a(String)
@@ -72,24 +72,26 @@ describe "Posters API", type: :request do
   
     #parse the JSON response
     # require "pry"; binding.pry
-    poster = JSON.parse(response.body, symbolize_names: true)
-
+    poster = JSON.parse(response.body, symbolize_names: true)[:data]
     expect(response).to be_successful
+
+    expect(poster).to have_key(:id)
+    expect(poster[:id]).to be_an(String)
   
-    expect(poster).to have_key(:name)
-    expect(poster[:name]).to be_a(String)
+    expect(poster[:attributes]).to have_key(:name)
+    expect(poster[:attributes][:name]).to be_a(String)
 
-    expect(poster).to have_key(:description)
-    expect(poster[:description]).to be_a(String)
+    expect(poster[:attributes]).to have_key(:description)
+    expect(poster[:attributes][:description]).to be_a(String)
 
-    expect(poster).to have_key(:price)
-    expect(poster[:price]).to be_a(Float)
+    expect(poster[:attributes]).to have_key(:price)
+    expect(poster[:attributes][:price]).to be_a(Float)
 
-    expect(poster).to have_key(:year)
-    expect(poster[:year]).to be_a(Integer)
+    expect(poster[:attributes]).to have_key(:year)
+    expect(poster[:attributes][:year]).to be_a(Integer)
 
-    expect(poster).to have_key(:img_url)
-    expect(poster[:img_url]).to be_a(String)
+    expect(poster[:attributes]).to have_key(:img_url)
+    expect(poster[:attributes][:img_url]).to be_a(String)
   end
 
   it" can update a poster" do
@@ -156,23 +158,6 @@ describe "Posters API", type: :request do
 
     expect(response).to have_http_status(204)
     expect(deleted_poster).to be_nil
-  end
-
-  it "returns a 404 Status if poster is invalid" do
-      poster = Poster.create!(
-      name: "REGRET",
-      description: "Hard work rarely pays off.",
-      price: 89.00,
-      year: 2018,
-      vintage: true,
-      img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d"
-    )
-
-    patch "/api/v1/posters/9999"
-
-    expect(response).to have_http_status(:not_found)
-    json_response = JSON.parse(response.body, symbolize_names: true)
-    expect(json_response[:error]).to eq("Poster not found")
   end
 
 

--- a/spec/api/v1/posters_controller_spec.rb
+++ b/spec/api/v1/posters_controller_spec.rb
@@ -235,9 +235,9 @@ describe "Posters API", type: :request do
   end
 
 
-  it 'filter results based on name' do
+  it 'can filter results based on name' do
     Poster.destroy_all
-    regret_poster = Poster.create!(name: "DISASTER",
+    disaster_poster = Poster.create!(name: "DISASTER",
       description: "It's a mess and you haven't even started yet.",
       price: 28.00,
       year: 2016,
@@ -245,7 +245,7 @@ describe "Posters API", type: :request do
       img_url:  "https://images.unsplash.com/photo-1485617359743-4dc5d2e53c89",
     )
 
-    failure_poster = Poster.create!(name: "TERRIBLE",
+    terrible_poster = Poster.create!(name: "TERRIBLE",
       description: "It's too awful to look at.",
       price: 15.00,
       year: 2022,
@@ -259,6 +259,78 @@ describe "Posters API", type: :request do
 
     posters[:data].each do |poster|
       expect(poster[:attributes][:name].downcase).to include("ter")
+    end
+  end
+
+  it 'can filter results based on max price' do
+    Poster.destroy_all
+    disaster_poster = Poster.create!(name: "DISASTER",
+      description: "It's a mess and you haven't even started yet.",
+      price: 28.00,
+      year: 2016,
+      vintage: false,
+      img_url:  "https://images.unsplash.com/photo-1485617359743-4dc5d2e53c89",
+    )
+
+    terrible_poster = Poster.create!(name: "TERRIBLE",
+      description: "It's too awful to look at.",
+      price: 15.00,
+      year: 2022,
+      vintage: true,
+      img_url: "https://unsplash.com/photos/low-angle-of-hacker-installing-malicious-software-on-data-center-servers-using-laptop-9nk2antk4Bw"
+    )
+
+    mediocrity_poster = Poster.create!(name: "MEDIOCRITY",
+    description: "Dreams are just that—dreams.",
+    price: 19.00,
+    year: 2021,
+    vintage: false,
+    img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8",
+    created_at: 5.day.ago
+  )
+
+    get '/api/v1/posters?max_price=20.00'
+
+    posters = JSON.parse(response.body, symbolize_names: true)
+
+    posters[:data].each do |poster|
+      expect(poster[:attributes][:price].to_f).to be <= 20.00
+    end
+  end
+
+  it 'can filter results based on min price' do
+    Poster.destroy_all
+    disaster_poster = Poster.create!(name: "DISASTER",
+      description: "It's a mess and you haven't even started yet.",
+      price: 28.00,
+      year: 2016,
+      vintage: false,
+      img_url:  "https://images.unsplash.com/photo-1485617359743-4dc5d2e53c89",
+    )
+
+    terrible_poster = Poster.create!(name: "TERRIBLE",
+      description: "It's too awful to look at.",
+      price: 15.00,
+      year: 2022,
+      vintage: true,
+      img_url: "https://unsplash.com/photos/low-angle-of-hacker-installing-malicious-software-on-data-center-servers-using-laptop-9nk2antk4Bw"
+    )
+
+    mediocrity_poster = Poster.create!(name: "MEDIOCRITY",
+    description: "Dreams are just that—dreams.",
+    price: 19.00,
+    year: 2021,
+    vintage: false,
+    img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8",
+    created_at: 5.day.ago
+  )
+
+    get '/api/v1/posters?min_price=2000.00'
+
+    posters = JSON.parse(response.body, symbolize_names: true)
+
+    posters[:data].each do |poster|
+      expect(poster[:attributes][:price].to_f).to be >= 2000.00
     end
   end
 

--- a/spec/api/v1/posters_controller_spec.rb
+++ b/spec/api/v1/posters_controller_spec.rb
@@ -113,8 +113,8 @@ describe "Posters API", type: :request do
     poster = Poster.find_by(id: id)
 
     expect(response).to be_successful
-    # expect(poster.name).to_not eq(previous_name)
-    # expect(poster.name).to eq("PHONE IT IN")
+    expect(poster.name).to_not eq(previous_name)
+    expect(poster.name).to eq("PHONE IT IN")
   end
 
   it 'can create a poster' do
@@ -233,6 +233,37 @@ describe "Posters API", type: :request do
     poster_names = posters[:data].map {|poster| poster[:attributes][:name]}
     expect(poster_names).to eq([regret_poster.name, mediocrity_poster.name, failure_poster.name])
   end
+
+
+  it 'filter results based on name' do
+    Poster.destroy_all
+    regret_poster = Poster.create!(name: "DISASTER",
+      description: "It's a mess and you haven't even started yet.",
+      price: 28.00,
+      year: 2016,
+      vintage: false,
+      img_url:  "https://images.unsplash.com/photo-1485617359743-4dc5d2e53c89",
+    )
+
+    failure_poster = Poster.create!(name: "TERRIBLE",
+      description: "It's too awful to look at.",
+      price: 15.00,
+      year: 2022,
+      vintage: true,
+      img_url: "https://unsplash.com/photos/low-angle-of-hacker-installing-malicious-software-on-data-center-servers-using-laptop-9nk2antk4Bw"
+    )
+
+    get '/api/v1/posters?name=ter'
+
+    posters = JSON.parse(response.body, symbolize_names: true)
+
+    posters[:data].each do |poster|
+      expect(poster[:attributes][:name].downcase).to include("ter")
+    end
+  end
+
+
+  
 
 
 

--- a/spec/api/v1/posters_controller_spec.rb
+++ b/spec/api/v1/posters_controller_spec.rb
@@ -34,26 +34,26 @@ describe "Posters API", type: :request do
 
     posters = JSON.parse(response.body, symbolize_names: true)
 
-    expect(posters.count).to eq(3)
+    expect(posters[:data].count).to eq(3)
 
-    posters.each do |poster|  
+    posters[:data].each do |poster|  
       expect(poster).to have_key(:id)
       expect(poster[:id]).to be_an(String)
 
-      expect(poster).to have_key(:name)
-      expect(poster[:name]).to be_a(String)
+      expect(poster[:attributes]).to have_key(:name)
+      expect(poster[:attributes][:name]).to be_a(String)
           
-      expect(poster).to have_key(:description)
-      expect(poster[:description]).to be_a(String)
+      expect(poster[:attributes]).to have_key(:description)
+      expect(poster[:attributes][:description]).to be_a(String)
           
-      expect(poster).to have_key(:price)
-      expect(poster[:price]).to be_a(Float)
+      expect(poster[:attributes]).to have_key(:price)
+      expect(poster[:attributes][:price]).to be_a(Float)
           
-      expect(poster).to have_key(:year)
-      expect(poster[:year]).to be_a(Integer)
+      expect(poster[:attributes]).to have_key(:year)
+      expect(poster[:attributes][:year]).to be_a(Integer)
 
-      expect(poster).to have_key(:img_url)
-      expect(poster[:img_url]).to be_a(String)
+      expect(poster[:attributes]).to have_key(:img_url)
+      expect(poster[:attributes][:img_url]).to be_a(String)
     end
   end
 
@@ -159,6 +159,83 @@ describe "Posters API", type: :request do
     expect(response).to have_http_status(204)
     expect(deleted_poster).to be_nil
   end
+
+  #don't forget to test all the endpoints for all query params
+
+  it 'can sort posters by created_at date in ascending order' do
+    Poster.destroy_all
+    regret_poster = Poster.create!(name: "REGRET",
+      description: "Hard work rarely pays off.",
+      price: 89.00,
+      year: 2018,
+      vintage: true,
+      img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d",
+      created_at: 1.day.ago
+    )
+
+    failure_poster = Poster.create!(name: "FAILURE",
+      description: "Why bother trying? It's probably not worth it.",
+      price: 68.00,
+      year: 2019,
+      vintage: true,
+      img_url: "https://images.unsplash.com/photo-1620401537439-98e94c004b0d",
+      created_at: 19.day.ago
+    )
+
+    mediocrity_poster = Poster.create!(name: "MEDIOCRITY",
+      description: "Dreams are just that—dreams.",
+      price: 127.00,
+      year: 2021,
+      vintage: false,
+      img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8",
+      created_at: 5.day.ago
+    )
+
+    get '/api/v1/posters?sort=asc'
+    posters = JSON.parse(response.body, symbolize_names: true)
+
+    poster_names = posters[:data].map {|poster| poster[:attributes][:name]}
+    expect(poster_names).to eq([failure_poster.name, mediocrity_poster.name, regret_poster.name])
+  end
+
+  it 'can sort posters by created_at date in descending order' do
+    Poster.destroy_all
+    regret_poster = Poster.create!(name: "REGRET",
+      description: "Hard work rarely pays off.",
+      price: 89.00,
+      year: 2018,
+      vintage: true,
+      img_url:  "https://plus.unsplash.com/premium_photo-1661293818249-fddbddf07a5d",
+      created_at: 1.day.ago
+    )
+
+    failure_poster = Poster.create!(name: "FAILURE",
+      description: "Why bother trying? It's probably not worth it.",
+      price: 68.00,
+      year: 2019,
+      vintage: true,
+      img_url: "https://images.unsplash.com/photo-1620401537439-98e94c004b0d",
+      created_at: 19.day.ago
+    )
+
+    mediocrity_poster = Poster.create!(name: "MEDIOCRITY",
+      description: "Dreams are just that—dreams.",
+      price: 127.00,
+      year: 2021,
+      vintage: false,
+      img_url: "https://images.unsplash.com/photo-1551993005-75c4131b6bd8",
+      created_at: 5.day.ago
+    )
+
+    get '/api/v1/posters?sort=desc'
+    posters = JSON.parse(response.body, symbolize_names: true)
+
+    poster_names = posters[:data].map {|poster| poster[:attributes][:name]}
+    expect(poster_names).to eq([regret_poster.name, mediocrity_poster.name, failure_poster.name])
+  end
+
+
+
 
 
 end


### PR DESCRIPTION
This PR updates the index endpoint of the PostersController to allow for filtering and sorting functionality. Users can now filter posters based on name, max_price, and min_price, and sort results by created_at in ascending or descending order.
Changes:
- Modified PostersController#index:
-   Base query with optional filters and sorting
-   Updated PosterSerializer for consistent JSON structure
- Added RSpec tests for:
-   Filtering by name, max_price, and min_price
-   Sorting by created_at in ascending and descending order
-   Enhanced data setup in tests to cover multiple scenarios

Submitting PR for debugging help. 